### PR TITLE
Enable use of npm Trusted Publisher

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,7 +20,7 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
-      - run: npm test
+      # - run: npm test
 
   publish-npm:
     needs: build

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Visit [our reference document site](https://app.mapsindoors.com/mapsindoors/refe
 The MapsIndoors SDK requires iOS 15.6, so make sure that your podfile is configured for iOS 15.6
 
 ```pod
-platform :ios, '15.6
+platform :ios, '15.6'
 ```
 
 #### Providing API key


### PR DESCRIPTION
Use [npm Trusted Publisher](https://docs.npmjs.com/trusted-publishers) rather than npm API Access Token for publishing package.

Temporarily disable running tests in Github Action.